### PR TITLE
class/runit: ensure run script permission during install

### DIFF
--- a/classes/runit.bbclass
+++ b/classes/runit.bbclass
@@ -28,6 +28,7 @@ install_runit_services() {
         mkdir -p ${D}${runit-svcdir}
 
         cp -rap --no-preserve=ownership ${WORKDIR}/sv/* ${D}${runit-svcdir}
+        chmod u+x ${D}${runit-svcdir}/*/run
     fi
 }
 do_install[postfuncs] += "${@bb.utils.contains('DISTRO_FEATURES', 'runit', 'install_runit_services', '', d)} "


### PR DESCRIPTION
Sorry to make it a two patch day. PR #1 didn't work, permission is still not correct after install.

---

This patch ensures that all the run scripts have at least u+x
permission so that default builds won't end up with run scripts
that cannot be executed.

NOTE: there is probably somewhere in bitbake where the files folders
      are copied into the build directory that is undoing the
      permissions at least for /etc/sv/gpsd/run. If we can find that
      one then this commit can be reverted.