### PR TITLE
recipes-navigation/gpsd: fix gpsd location

### DIFF
--- a/recipes-navigation/gpsd/files/sv/gpsd/run
+++ b/recipes-navigation/gpsd/files/sv/gpsd/run
@@ -1,4 +1,4 @@
 #!/bin/sh
 [ -r /etc/default/gpsd ] && . /etc/default/gpsd
-exec /usr/bin/gpsd -N -F /run/gpsd.sock $OPTS ${DEV:=/dev/gps0}
+exec /usr/sbin/gpsd -N -F /run/gpsd.sock $OPTS ${DEV:=/dev/gps0}
 


### PR DESCRIPTION
The default yocto install of gpsd places the gpsd binary
in the /usr/sbin folder following the FHS v3.0, the
/usr/bin is for non-essential command not intended for
single user, and for all users, while the /usr/sbin/ folder
is for non-essential system binaries (such as daemons
and network services).

In this case, our original template (Void Linux) symlinks
/usr/sbin to /usr/bin and thus satisfies both requirements
by combination. For the Yocto build, we will need to split
it back out.