### PR TITLE
Bugfix: klogd needs to depend on syslogd

### DIFF
--- a/recipes-core/runit-base-services/files/sv/klog/run
+++ b/recipes-core/runit-base-services/files/sv/klog/run
@@ -1,2 +1,3 @@
 #!/bin/sh
+sv start syslog || exit 1
 exec /sbin/klogd -n 2>&1


### PR DESCRIPTION
Klogd sends via unix domain socket the kernel logs
at boot time, and if syslogd is not up, those messages
will be missed by syslogd.