### PR TITLE
hostapd fails to launch

### DIFF
--- a/recipes-connectivity/hostapd/files/sv/hostapd/run
+++ b/recipes-connectivity/hostapd/files/sv/hostapd/run
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec hostapd -s /etc/hostapd/hostapd.conf 2>&1
+exec hostapd /etc/hostapd/hostapd.conf 2>&1


### PR DESCRIPTION
This run file uses the -s flag to specify a configuration file. However, hostapd takes the configuration location as an argument directly.