### PR TITLE
Fix bluez

### DIFF
--- a/recipes-connectivity/bluez5/bluez5_%.bbappend
+++ b/recipes-connectivity/bluez5/bluez5_%.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # This is an annex of the original metadata.  So, if you modify this file, bump
 # the number in this .bbappend to reflect the change and force a re-build.
-PR =. "+runit-r1"
+PR =. "+runit-r2"
 
 # Add the services set(s)...
 SRC_URI += " \
@@ -37,5 +37,5 @@ do_deletes() {
         rm -rvf ${D}/$DELETE
     done
 }
-do_install[postfuncs] = " do_deletes "
+do_install[postfuncs] += "${@bb.utils.contains('DISTRO_FEATURES', 'runit', 'do_deletes', '', d)} "
 

--- a/recipes-connectivity/bluez5/files/sv/bluetooth/run
+++ b/recipes-connectivity/bluez5/files/sv/bluetooth/run
@@ -1,4 +1,4 @@
 #!/bin/sh
-sv check messagebus > /dev/null || exit 1
-exec /usr/libexec/bluetooth/bluetoothd -n > /dev/null
+sv check messagebus || exit 1
+exec /usr/libexec/bluetooth/bluetoothd -n 2>&1
 


### PR DESCRIPTION
When building for the raspberry pi 4/5, I noticed that run script for bluez was not present. Looking at the run.do_install script, I noticed that none of the do_install postfuncs from https://github.com/madscientist42/meta-runit/blob/master/classes/runit.bbclass were running. I found that the bluez recipe was overwriting the functions when adding `do_deletes` rather than appending to them. I also matched the format that is done in other recipes here to only append `do_deletes` to `do_install[postfuncs]` if `runit` is in `DISTRO_FEATURES`.

I also ran into an issue that the bluetooth service was not starting. I updated the bluetooth `run` script, and now the service starts.

With these changes, the run script is now present and I have Bluetooth running on my pi.